### PR TITLE
Add Claude Code launch config for local dev preview

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "portfolio-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 5173
+    }
+  ]
+}


### PR DESCRIPTION
Enables the dev server (vite) to be opened in the Browser pane for visual review while exploring portfolio redesign directions.